### PR TITLE
Fix issue that prevented osx and linux build.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
   sha256: b57c2d3362102a77955d3cd0181b792c496520349bfefee8379b9d35b8819f80
 
 build:
-  skip: true  # [vc<14]
-  number: 0
+  skip: true  # [win and vc<14]
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Fix issue that prevented osx and linux build.
@conda-forge-admin, please

selector was preventing osx and linux builds.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
